### PR TITLE
Delete previous workouts but do not create new ones

### DIFF
--- a/src/Command/WorkoutCommand.php
+++ b/src/Command/WorkoutCommand.php
@@ -47,6 +47,7 @@ class WorkoutCommand extends Command
             ->addOption('email', 'm',InputOption::VALUE_REQUIRED, 'Email to login to Garmin', '')
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'Password to login to Garmin', '')
             ->addOption('delete', 'x', InputOption::VALUE_NONE, 'Delete previous workouts')
+            ->addOption('delete-only', 'X', InputOption::VALUE_NONE, 'Delete previous workouts but do not create new ones')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Dry run that will prevent anything from being created or deleted from Garmin')
             ->addOption('prefix', 'r', InputOption::VALUE_OPTIONAL, 'A prefix to put before every workout name/title', null)
             ->addOption('start', 's', InputOption::VALUE_REQUIRED, 'Date of the first day of the first week of the plan')
@@ -65,6 +66,7 @@ class WorkoutCommand extends Command
         $prefix = $input->getOption('prefix');
         $dryrun = $input->getOption('dry-run');
         $delete = $input->getOption('delete');
+        $deleteOnly = $input->getOption('delete-only');
         $path = $input->getArgument('csv');
         $start = $input->getOption('start');
         $end = $input->getOption('end');
@@ -75,7 +77,8 @@ class WorkoutCommand extends Command
         $handlerOptions->setPassword($password);
         $handlerOptions->setPrefix($prefix);
         $handlerOptions->setDryrun($dryrun);
-        $handlerOptions->setDelete($delete);
+        $handlerOptions->setDelete($delete||$deleteOnly);
+        $handlerOptions->setDeleteOnly($deleteOnly);
         $handlerOptions->setPath($path);
         $handlerOptions->setStartDate($start);
         $handlerOptions->setEndDate($end);

--- a/src/Library/Handler/AbstractHandler.php
+++ b/src/Library/Handler/AbstractHandler.php
@@ -89,6 +89,10 @@ abstract class AbstractHandler implements HandlerInterface
 
     public function createWorkouts(HandlerOptions $handlerOptions, array $days)
     {
+        if ($handlerOptions->getDeleteOnly()) {
+            return;
+        }
+
         $debugMessages = [];
         $event = new HandlerEvent($handlerOptions);
         $this->dispatcher->dispatch($event, HandlerEvents::CREATED_WORKOUTS_STARTED);
@@ -157,6 +161,10 @@ abstract class AbstractHandler implements HandlerInterface
 
     public function attachNotes(HandlerOptions $handlerOptions, PeriodCollection $period)
     {
+        if ($handlerOptions->getDeleteOnly()) {
+            return;
+        }
+        
         $steps = $period->getStepsWithNotes();
 
         //Loop through steps and add their notes

--- a/src/Library/Handler/HandlerOptions.php
+++ b/src/Library/Handler/HandlerOptions.php
@@ -27,6 +27,11 @@ class HandlerOptions
     private $delete;
 
     /**
+     * @var bool|false
+     */
+    private $deleteOnly;
+
+    /**
      * @var DateTime|string|null
      */
     private $startDate;
@@ -120,6 +125,24 @@ class HandlerOptions
     public function setDelete($delete)
     {
         $this->delete = $delete;
+        return $this;
+    }
+
+    /**
+     * @return bool|false
+     */
+    public function getDeleteOnly()
+    {
+        return $this->deleteOnly;
+    }
+
+    /**
+     * @param bool|false $deleteOnly
+     * @return HandlerOptions
+     */
+    public function setDeleteOnly($deleteOnly)
+    {
+        $this->deleteOnly = $deleteOnly;
         return $this;
     }
 


### PR DESCRIPTION
The parameter 'delete-only' allows to delete workouts/schedules but skip the creation step.
It can help to keep workout list small.