### PR TITLE
Identical workouts in plan support

### DIFF
--- a/tests/Resource/3-weeks-plan.csv
+++ b/tests/Resource/3-weeks-plan.csv
@@ -1,0 +1,59 @@
+"WEEK","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"
+"1","","running: 6x3'@5k recover decreases
+- warmup: lap-button
+- run: 3:00 @3:50-3:54 mpk; @5k
+- recover: 02:30
+- run: 3:00 @3:50-3:54 mpk; @5k
+- recover: 2:00
+- run: 3:00 @3:50-3:54 mpk; @5k
+- recover: 1:30
+- run: 3:00 @3:50-3:54 mpk; @5k
+- recover: 1:00
+- run: 3:00 @3:50-3:54 mpk; @5k
+- recover: 00:30
+- run: 3:00 @3:50-3:54 mpk; @5k
+- recover: lap-button","running: 40'@z2-3
+- run: 40:00 @128 - 154 bpm","","running: 9x1'@5k r2'
+- warmup: 25:00 @128 - 154 bpm
+- repeat: 9
+   - run: 1:00 @3:45-3:55 mpk; @5k
+   - recover: 2:00 @z2
+- recover: 10:00 @z1","running: 30'@z3
+- warmup: 20:00 @128 - 154 bpm
+- run: 30:00 @z3
+- recover: 10:00 @z1","cycling: 2hrs cycling
+- bike: 120:00"
+"","","running: 4'@VO2Max 8'@5k 12'@10k
+- warmup: lap-button
+- run: 4:00 @3:43-3:47 mpk; @VO2Max
+- recover: 4:00
+- run: 8:00 @3:50-3:54 mpk; @5k
+- recover: 4:00
+- run: 12:00 @3:55-3:59 mpk; @10k
+- recover: lap-button","running: 40'@z2-3
+- run: 40:00 @128 - 154 bpm","","running: 9x1'@5k r1'30
+- warmup: 25:00 @128 - 154 bpm
+- repeat: 9
+   - run: 1:00 @3:45-3:55 mpk; @5k
+   - recover: 1:30 @z2
+- recover: 10:00 @z1","running: 40'@z3
+- warmup: 20:00 @128 - 154 bpm
+- run: 40:00 @z3
+- recover: 10:00 @z1","cycling: 3hrs cycling
+- bike: 180:00"
+"","","running: 2x12'@AS10-AS21
+- warmup: lap-button
+- repeat: 2
+  - run: 12:00 @3:55-4:08 mpk; @10k-21k
+  - recover: 4:00
+- recover: lap-button","cycling: 1hr30 cycling @z1
+- bike: 90:00 @z1","","running: 9x1'@5k r1'30
+- warmup: 25:00 @128 - 154 bpm
+- repeat: 9
+   - run: 1:00 @3:45-3:55 mpk; @5k
+   - recover: 1:30 @z2
+- recover: 10:00 @z1","running: 50'@z3
+- warmup: 20:00 @128 - 154 bpm
+- run: 40:00 @z3
+- recover: 10:00 @z1","cycling: cycle@feelings
+- bike: lap-button"


### PR DESCRIPTION
This PR fixes workout deletion step in case of multiple workouts with the same name exist.
```bash
./bin/console garmin:workout tests/Resource/3-weeks-plan.csv import -n -x
```
"40'@z2-3" and "9x1'@5k r1'30" are created 2 times, OK no big deal but a new delete/import will fail
```bash
./bin/console garmin:workout tests/Resource/3-weeks-plan.csv import -n -x
...
[error] Error thrown while running command "garmin:workout 'tests/Resource/3-weeks-plan.csv' import -n -x". Message: "An unexpected response code was found: 404"

In GarminConnect.php line 320:
                                             
  An unexpected response code was found: 404
```
It crashes because it tries to delete the "40'@z2-3" workout 2 times.
* Fix: src/Library/Handler/AbstractHandler.php L162 while + L166 unset -> all workouts with name $workoutName will be deleted

* Improvment: src/Library/Handler/AbstractHandler.php L100-129

```bash
# delete previous import
./bin/console garmin:workout tests/Resource/3-weeks-plan.csv import -n --delete-only
./bin/console garmin:workout tests/Resource/3-weeks-plan.csv schedule --start 2020-12-14 --no-interaction --delete
```
see in output "Workout - 40'@z2-3 was previously created on the Garmin website with the id"
It will re-use existing workouts.
