### PR TITLE
Added sub repeaters and workouts as Yaml

### DIFF
--- a/src/Library/Parser/Model/Workout/AbstractWorkout.php
+++ b/src/Library/Parser/Model/Workout/AbstractWorkout.php
@@ -35,67 +35,42 @@ abstract class AbstractWorkout implements \JsonSerializable
         $repeaterStep = null;
 
         foreach ($steps as $index => $step) {
-            $repeater = $this->isRepeaterStep($step);
-            $header = $this->parseStepHeader($step);
-            $parameters = $this->parseStepDetails($step);
-            $notes = $this->parseStepNotes($step);
+            $header = array_key_first($step);
+            $parameters = $step[$header];
+            $notes = array_key_exists("notes", $step) ? $step["notes"] : "";
+
             if ($header === 'repeat') {
                 $repeaterStep = new RepeaterStep($parameters, $index);
                 $this->steps->add($repeaterStep);
+                $this->addStepsToRepeater($step["steps"], $repeaterStep, 1);
             } else {
-                if ($repeater && $repeaterStep) {
-                    $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
-                    $repeaterStep->addStep($stepFactory);
-                } else {
-                    $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
-                    $this->steps->add($stepFactory);
-                }
+                $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
+                $this->steps->add($stepFactory);
             }
         }
 
         return $this;
     }
 
-    public function isRepeaterStep($stepText)
+    private function addStepsToRepeater($steps, $repeaterStep, $level)
     {
-        $regex = '/^\s{1,}-.*$/';
+        $subRepeaterStep = null;
+        
+        foreach ($steps as $index => $step) {
+            $header = array_key_first($step);
+            $parameters = $step[$header];
+            $notes = array_key_exists("notes", $step) ? $step["notes"] : "";
 
-        $result = preg_match($regex, $stepText, $stepHeader);
-
-        return $result && isset($stepHeader[0]) && ! empty($stepHeader[0]);
-    }
-
-    public function parseStepHeader($stepText)
-    {
-        $regex = '/-\s*([^:]*)/';
-        $result = preg_match($regex, $stepText, $stepHeader);
-
-        if ($result && isset($stepHeader[1]) && ! empty($stepHeader[1])) {
-            return trim($stepHeader[1]);
-        }
-
-        return null;
-    }
-
-    public function parseStepDetails($stepText)
-    {
-        $regex = '/:\s*([^;]*)/';
-        $result = preg_match($regex, $stepText, $stepDetails);
-
-        if ($result && isset($stepDetails[1]) && ! empty($stepDetails[1])) {
-            return trim($stepDetails[1]);
-        }
-
-        return null;
-    }
-
-    public function parseStepNotes($stepText)
-    {
-        $regex = '/;\s*(.*)/';
-        $result = preg_match($regex, $stepText, $stepNotes);
-
-        if ($result && isset($stepNotes[1]) && ! empty($stepNotes[1])) {
-            return trim($stepNotes[1]);
+            if ($header === 'repeat') {
+                $subRepeaterStep = new RepeaterStep($parameters, $index);
+                $repeaterStep->addStep($subRepeaterStep);
+                $nextLevel = $level + 1;
+                $this->addStepsToRepeater($step["steps"], $subRepeaterStep, $nextLevel);
+            }
+            else {
+                $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
+                $repeaterStep->addStep($stepFactory);
+            }
         }
 
         return null;

--- a/src/Library/Parser/Parser.php
+++ b/src/Library/Parser/Parser.php
@@ -8,6 +8,7 @@ use App\Library\Parser\Model\PeriodCollection;
 use App\Library\Parser\Model\WeekCollection;
 use App\Library\Parser\Model\Workout\WorkoutFactory;
 use League\Csv\Reader;
+use Symfony\Component\Yaml\Yaml;
 use DateTime;
 
 class Parser
@@ -176,15 +177,11 @@ class Parser
 
     public function parseSteps($stepsText)
     {
-        $regex = '/^(\s*-.*)$/m';
-
-        $result = preg_match_all($regex, $stepsText, $steps);
-
-        if ($result && isset($steps[0]) && ! empty($steps[0])) {
-            return $steps[0];
-        }
-
-        return null;
+        // create a valid parseable Yaml string
+        $stepsText = preg_replace("/(( *)- repeat: \d+)\n/", "$1\n$2  steps:\n", $stepsText);
+        $stepsText = preg_replace("/(( *)- \w+:.*);\s*(.*)\n/", "$1\n$2  notes: \"$3\"\n", $stepsText);
+        $steps = Yaml::parse($stepsText);
+        return $steps;
     }
 
     public function parseWorkout($workoutText)


### PR DESCRIPTION
Support of sub repeaters (repeat step in a repeat step).

Workout example:  
```yaml
running: test repeat
- warmup: 20:00 @z2 ;L0 warmup z2
- repeat: 2
  - warmup: 1:00 @z3 ;L1 warmup z3
  - repeat: 3
    - repeat: 4
      - run: 00:30 @3:30-3:46 mpk ;@105%VMA
      - recover: 00:30 ;L3 recover
    - recover: 2:00 @z2 ;L2 recover
  - recover: 2:00 @z2 ;L1 recover
- recover: 10:00 @z1 ;L0 recover
```

Internally, the parsing of the workout string is facilitated by treating it as a Yaml document.