### PR TITLE
feat: subrepeaters, yaml parser

### DIFF
--- a/src/Library/Parser/Model/Workout/AbstractWorkout.php
+++ b/src/Library/Parser/Model/Workout/AbstractWorkout.php
@@ -35,17 +35,15 @@ abstract class AbstractWorkout implements \JsonSerializable
         $repeaterStep = null;
 
         foreach ($steps as $index => $step) {
-            $repeater = $this->isRepeaterStep($step);
-            $header = $this->parseStepHeader($step);
-            $parameters = $this->parseStepDetails($step);
-            $notes = $this->parseStepNotes($step);
-            if ($header === 'repeat') {
-                $repeaterStep = new RepeaterStep($parameters, $index);
-                $this->steps->add($repeaterStep);
-            } else {
-                if ($repeater && $repeaterStep) {
-                    $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
-                    $repeaterStep->addStep($stepFactory);
+            if (is_array($step)) {
+                $header = array_key_first($step);
+                $parameters = $step[$header];
+                $notes = array_key_exists("notes", $step) ? $step["notes"] : "";
+
+                if ($header === 'repeat') {
+                    $repeaterStep = new RepeaterStep($parameters, $index);
+                    $this->steps->add($repeaterStep);
+                    $this->addStepsToRepeater($step["steps"], $repeaterStep, 1);
                 } else {
                     $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
                     $this->steps->add($stepFactory);
@@ -56,46 +54,27 @@ abstract class AbstractWorkout implements \JsonSerializable
         return $this;
     }
 
-    public function isRepeaterStep($stepText)
+    private function addStepsToRepeater($steps, $repeaterStep, $level)
     {
-        $regex = '/^\s{1,}-.*$/';
+        $subRepeaterStep = null;
+        
+        foreach ($steps as $index => $step) {
+            if (is_array($step)) {
+                $header = array_key_first($step);
+                $parameters = $step[$header];
+                $notes = array_key_exists("notes", $step) ? $step["notes"] : "";
 
-        $result = preg_match($regex, $stepText, $stepHeader);
-
-        return $result && isset($stepHeader[0]) && ! empty($stepHeader[0]);
-    }
-
-    public function parseStepHeader($stepText)
-    {
-        $regex = '/-\s*([^:]*)/';
-        $result = preg_match($regex, $stepText, $stepHeader);
-
-        if ($result && isset($stepHeader[1]) && ! empty($stepHeader[1])) {
-            return trim($stepHeader[1]);
-        }
-
-        return null;
-    }
-
-    public function parseStepDetails($stepText)
-    {
-        $regex = '/:\s*([^;]*)/';
-        $result = preg_match($regex, $stepText, $stepDetails);
-
-        if ($result && isset($stepDetails[1]) && ! empty($stepDetails[1])) {
-            return trim($stepDetails[1]);
-        }
-
-        return null;
-    }
-
-    public function parseStepNotes($stepText)
-    {
-        $regex = '/;\s*(.*)/';
-        $result = preg_match($regex, $stepText, $stepNotes);
-
-        if ($result && isset($stepNotes[1]) && ! empty($stepNotes[1])) {
-            return trim($stepNotes[1]);
+                if ($header === 'repeat') {
+                    $subRepeaterStep = new RepeaterStep($parameters, $index);
+                    $repeaterStep->addStep($subRepeaterStep);
+                    $nextLevel = $level + 1;
+                    $this->addStepsToRepeater($step["steps"], $subRepeaterStep, $nextLevel);
+                }
+                else {
+                    $stepFactory = StepFactory::build($header, $parameters, $notes, $index);
+                    $repeaterStep->addStep($stepFactory);
+                }
+            }
         }
 
         return null;

--- a/src/Library/Parser/Parser.php
+++ b/src/Library/Parser/Parser.php
@@ -7,6 +7,7 @@ use App\Library\Parser\Model\PeriodCollection;
 use App\Library\Parser\Model\WeekCollection;
 use App\Library\Parser\Model\Workout\WorkoutFactory;
 use League\Csv\Reader;
+use Symfony\Component\Yaml\Yaml;
 use DateTime;
 
 class Parser
@@ -166,15 +167,16 @@ class Parser
 
     public function parseSteps($stepsText)
     {
-        $regex = '/^(\s*-.*)$/m';
-
-        $result = preg_match_all($regex, $stepsText, $steps);
-
-        if ($result && isset($steps[0]) && ! empty($steps[0])) {
-            return $steps[0];
+        // create a valid parseable Yaml string
+        $stepsText = preg_replace("/(( *)- repeat: \d+)\n/", "$1\n$2  steps:\n", $stepsText);
+        $stepsText = preg_replace("/(( *)- \w+:.*);\s*(.*)\n/", "$1\n$2  notes: \"$3\"\n", $stepsText);
+        try {
+            $steps = Yaml::parse($stepsText);
+        } catch (ParseException $e) {
+            $steps = null;
         }
-
-        return null;
+        
+        return $steps;
     }
 
     public function parseWorkout($workoutText)


### PR DESCRIPTION
Re-add support of inner "repeat:". Invalid lines are ignored.