### PR TITLE
Auth: Add MFA support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,13 @@
         "ext-openssl": "*",
         "doctrine/collections": "^1.6",
         "league/csv": "^9.6",
+        "symfony/browser-kit": "6.4.*",
         "symfony/console": "6.4.*",
         "symfony/dotenv": "6.4.*",
         "symfony/flex": "^1.3.1",
         "symfony/framework-bundle": "6.4.*",
         "symfony/http-client": "6.4.*",
+        "symfony/mime": "6.4.*",
         "symfony/runtime": "6.4.*",
         "symfony/yaml": "6.4.*"
     },

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Http\GarminClient\GarminClient;
+use App\Http\Mfa\StyleCodeProvider;
 use App\Library\Handler\HandlerFactory;
 use App\Library\Handler\HandlerOptions;
 use App\Subscriber\WorkoutCommandSubscriber;
@@ -37,6 +38,9 @@ class TestCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $io->title('Starting GARMIN test command');
+
+        $mfaCodeProvider = new StyleCodeProvider($io);
+        $this->garminClient->setMfaCodeProvider($mfaCodeProvider);
 
         $this->garminClient->getWorkoutList(0, 9999);
 

--- a/src/Command/WorkoutCommand.php
+++ b/src/Command/WorkoutCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use App\Http\Mfa\StyleCodeProvider;
 use App\Library\Handler\HandlerFactory;
 use App\Library\Handler\HandlerOptions;
 use App\Subscriber\WorkoutCommandSubscriber;
@@ -84,7 +85,9 @@ or import **AND** schedule the workouts.', 'import')
 
         $this->registerSubscriber($io, $this->dispatcher);
 
-        $this->handlerFactory->buildCommand($handlerOptions);
+        $mfaCodeProvider = new StyleCodeProvider($io);
+
+        $this->handlerFactory->buildCommand($handlerOptions, $mfaCodeProvider);
 
         return Command::SUCCESS;
     }

--- a/src/Http/GarminClient/GarminClient.php
+++ b/src/Http/GarminClient/GarminClient.php
@@ -3,6 +3,7 @@
 namespace App\Http\GarminClient;
 
 use App\Http\GarminClient\GarminAuthenticator;
+use App\Http\Mfa\CodeProviderInterface;
 use Symfony\Component\HttpClient\HttpOptions;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -23,6 +24,11 @@ class GarminClient
         $this->garminAuthenticator->setGarminUsername($username);
         $this->garminAuthenticator->setGarminPassword($password);
     }
+
+    public function setMfaCodeProvider(CodeProviderInterface $codeProvider): void
+    {
+        $this->garminAuthenticator->setMfaCodeProvider($codeProvider);
+    }   
 
     public function setup(): void
     {

--- a/src/Http/Mfa/CodeProviderInterface.php
+++ b/src/Http/Mfa/CodeProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Mfa;
+
+interface CodeProviderInterface
+{
+    public function provide(): string;
+}

--- a/src/Http/Mfa/StyleCodeProvider.php
+++ b/src/Http/Mfa/StyleCodeProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Mfa;
+
+use Symfony\Component\Console\Style\StyleInterface;
+
+class StyleCodeProvider implements CodeProviderInterface
+{
+    private $style;
+
+    public function __construct(StyleInterface $style)
+    {
+        $this->style = $style;
+    }
+
+    public function provide(): string
+    {
+        return $this->style->askHidden('Enter the MFA code');
+    }
+}

--- a/src/Library/Handler/HandlerFactory.php
+++ b/src/Library/Handler/HandlerFactory.php
@@ -2,9 +2,7 @@
 
 namespace App\Library\Handler;
 
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\OutputStyle;
+use App\Http\Mfa\CodeProviderInterface;
 
 class HandlerFactory
 {
@@ -16,11 +14,12 @@ class HandlerFactory
     ) {
     }
 
-    public function buildCommand(HandlerOptions $handlerOptions)
+    public function buildCommand(HandlerOptions $handlerOptions, CodeProviderInterface $mfaCodeProvider): void
     {
         foreach ($this->iterableHandlers as $handler) {
             if ($handler->supports($handlerOptions->getCommand())) {
-                return $handler->handle($handlerOptions);
+                $handler->handle($handlerOptions, $mfaCodeProvider);
+                return;
             }
         }
 

--- a/src/Library/Handler/HandlerInterface.php
+++ b/src/Library/Handler/HandlerInterface.php
@@ -2,9 +2,11 @@
 
 namespace App\Library\Handler;
 
+use App\Http\Mfa\CodeProviderInterface;
+
 interface HandlerInterface
 {
-    public function handle(HandlerOptions $handlerOptions);
+    public function handle(HandlerOptions $handlerOptions, CodeProviderInterface $mfaCodeProvider): void;
 
     public function supports(string $command);
 }

--- a/src/Library/Handler/ScheduleHandler.php
+++ b/src/Library/Handler/ScheduleHandler.php
@@ -4,13 +4,15 @@ namespace App\Library\Handler;
 
 use App\Library\Handler\Event\HandlerEvent;
 use App\Library\Handler\Event\HandlerEvents;
+use App\Http\Mfa\CodeProviderInterface;
+
 use DateTime;
 
 class ScheduleHandler extends AbstractHandler
 {
-    public function handle(HandlerOptions $handlerOptions): void
+    public function handle(HandlerOptions $handlerOptions, CodeProviderInterface $mfaCodeProvider): void
     {
-        parent::handle($handlerOptions);
+        parent::handle($handlerOptions, $mfaCodeProvider);
 
         // Get and parse the inputted start and end date
         $start = $this->convertStringToDate($handlerOptions->getStartDate());

--- a/src/Service/GarminHelper.php
+++ b/src/Service/GarminHelper.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Http\GarminClient\GarminClient;
+use App\Http\Mfa\CodeProviderInterface;
 use App\Library\Parser\Model\Day;
 use App\Library\Parser\Model\Step\AbstractStep;
 use App\Library\Parser\Model\Workout\AbstractWorkout;
@@ -17,8 +18,10 @@ class GarminHelper
     ) {
     }
 
-    public function createGarminClient($username, $password): void
+    public function createGarminClient($username, $password, CodeProviderInterface $mfaCodeProvider): void
     {
+        $this->client->setMfaCodeProvider($mfaCodeProvider);
+
         if (empty($username)) {
             return;
         }

--- a/symfony.lock
+++ b/symfony.lock
@@ -2,6 +2,15 @@
     "doctrine/collections": {
         "version": "1.6.4"
     },
+    "doctrine/deprecations": {
+        "version": "1.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "87424683adc81d7dc305eefec1fced883084aab9"
+        }
+    },
     "doctrine/instantiator": {
         "version": "1.4.0"
     },


### PR DESCRIPTION
This adds MFA support to the authenticator.

**Example output**
```bash
➜  garmin-csv-plan git:(mfa-support) ✗ ./bin/console garmin:workout ../garmin_quickplan_final.csv schedule -s 2026-02-23

Starting workout import/export command
======================================

Validating and accessing - ../garmin_quickplan_final.csv
--------------------------------------------------------

                                                                                                                        
 [OK] File valid                                                                                                        
                                                                                                                        
Parsing Workouts
----------------

 * z2-45min

 Does the following look correct? (yes/no) [yes]:
 > yes

Creating workouts
-----------------

 Enter the MFA code:

 * Workout - z2-45min was created on the Garmin website with the id 1338467730

                                                                                                                        
 [OK] Workout import was successful.                                                                                    
...
```